### PR TITLE
Deps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 build/
 traces/
 *.out
+*.log

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tracer
 COPY tracer/package.json /tracer/
 COPY tracer/yarn.lock /tracer/
-RUN yarn
+RUN yarn && npm install -g npm-bundle
 # Separate the dependency install from the build to improve layer cache hits
 COPY tracer/ /tracer/
 # 1. Compile the application

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update && apt-get install -y \
 WORKDIR /tracer
 COPY tracer/package.json /tracer/
 COPY tracer/yarn.lock /tracer/
-RUN yarn && npm install -g npm-bundle
+RUN yarn
 # Separate the dependency install from the build to improve layer cache hits
 COPY tracer/ /tracer/
 # 1. Compile the application

--- a/readme.md
+++ b/readme.md
@@ -16,9 +16,28 @@ one's computer and pulling this git repo, `cd` into this repo the run the
 following commands. 
 
 ```[bash]
-mkdir traces // If you haven't already made a traces dir.  
+mkdir traces
 docker pull awendland/npm-install-hook-tracer:latest
 docker run -v "$PWD/traces:/workspace/traces" --cap-add SYS_PTRACE awendland/npm-install-hook-tracer PACKGE_NAME
+```
+
+## Development
+
+When developing:
+
+```sh
+# This will create a local dir to store the strace output
+mkdir traces
+# This will build an image according to the Dockerfile
+docker-compose build
+# This will run the docker image we just built (it's called "tracer")
+docker-compose run tracer PACKAGE_NAME
+```
+
+Easy (slow b/c sequential) batch run:
+
+```sh
+cat most-depended-upon.txt | xargs -n1 docker-compose run tracer ^&1 | tee most-depended-upon--traced.out
 ```
 
 ## TODO

--- a/readme.md
+++ b/readme.md
@@ -2,16 +2,28 @@
 
 ## Overview
 
-This tool will download a specified npm package, determine which install/uninstall hooks are registered, and run each of the associated scripts with `strace` attached to watch for file and network activity. It will output the recorded `strace` output to `/workspace/traces/${PACKAGE_NAME-VERSION}`. `strace` files will be named in the format `$HOOK_NAME.$PID`, ie `postinstall.45` (there may be multiple processes executed by each script).
+This tool will download a specified npm package, determine which
+install/uninstall hooks are registered, and run each of the associated scripts
+with `strace` attached to watch for file and network activity. It will output
+the recorded `strace` output to `/workspace/traces/${PACKAGE_NAME-VERSION}`.
+`strace` files will be named in the format `$HOOK_NAME.$PID`, ie
+`postinstall.45` (there may be multiple processes executed by each script).
 
 ## Usage
 
-```
+After [setting up Docker](https://www.docker.com/products/docker-desktop) on
+one's computer and pulling this git repo, `cd` into this repo the run the
+following commands. 
+
+```[bash]
+mkdir traces // If you haven't already made a traces dir.  
 docker pull awendland/npm-install-hook-tracer:latest
 docker run -v "$PWD/traces:/workspace/traces" --cap-add SYS_PTRACE awendland/npm-install-hook-tracer PACKGE_NAME
 ```
 
 ## TODO
 
-* Resolve package dependencies before running `install`, `postinstall`, and `preuninstall` scripts (since they may depend on a dependency specified in `package.json` to run, such as `node-pre-gyp` for `bcrypt`).
+* Resolve package dependencies before running `install`, `postinstall`, and
+  `preuninstall` scripts (since they may depend on a dependency specified in
+  `package.json` to run, such as `node-pre-gyp` for `bcrypt`).
 

--- a/tracer/package.json
+++ b/tracer/package.json
@@ -11,6 +11,7 @@
   "license": "ISC",
   "dependencies": {
     "minimist": "^1.2.0",
+    "npm-bundle": "^3.0.3",
     "shelljs": "^0.8.3",
     "tar": "^4.4.8"
   },

--- a/tracer/src/index.ts
+++ b/tracer/src/index.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import shell from 'shelljs'
+import { statSync } from 'fs'
 import path from 'path'
 import { performance } from 'perf_hooks'
 import * as lib from './lib'
@@ -25,7 +26,8 @@ const msToSec2 = (ms: number) => (ms / 1000).toFixed(2)
   process.stderr.write(`Retrieving "${packageName}" `)
   const downloadStart = performance.now()
   const {packageFile, extractedFolder} = await lib.pullPackage(packageName)
-  process.stderr.write(`time[${msToSec2(performance.now() - downloadStart)}s]\n`)
+  process.stderr.write(`time[${msToSec2(performance.now() - downloadStart)}s] `)
+  process.stderr.write(`size[${(statSync(packageFile).size / 1024).toFixed(2)}KiB]\n`)
   argv.traceDir = argv.traceDir || argv.o || `traces/${packageFile.replace('.tgz', '')}`
   console.error(`Analyzing "${packageFile}"`)
   const packageJson = require(path.resolve(extractedFolder, 'package.json'))
@@ -43,7 +45,7 @@ const msToSec2 = (ms: number) => (ms / 1000).toFixed(2)
     const {traceFiles, stdout, stderr, runtime} =
       await lib.straceScript(path.resolve(argv.traceDir, `${hook}`), script, extractedFolder)
     const traceSize = traceFiles.reduce((sum, stat) => sum + stat.size, 0)
-    process.stderr.write(`traces[${traceFiles.length}] size[${traceSize / 1024}KiB] time[${msToSec2(runtime)}s]\n`)
+    process.stderr.write(`traces[${traceFiles.length}] size[${(traceSize / 1024).toFixed(2)}KiB] time[${msToSec2(runtime)}s]\n`)
   }
 })().catch(e => {
   console.error(e)

--- a/tracer/src/lib.ts
+++ b/tracer/src/lib.ts
@@ -14,8 +14,9 @@ const asyncExecFile = promisify(execFile)
  * directory.
  */
 export const pullPackage = async (packageName: string): Promise<{packageFile: string, extractedFolder: string}> => {
-  const {stdout: packStdout} = await asyncExecFile('npm', ['pack', packageName])
+  const {stdout: packStdout} = await asyncExecFile('npm-bundle', [packageName])
   const packageFile = packStdout.trim()
+  console.error(`PACKAGEFILE: ${packageFile}`)
   const precontents = new Set(shell.ls())
   await tar.extract({file: packageFile})
   const postcontents = new Set(shell.ls())

--- a/tracer/src/lib.ts
+++ b/tracer/src/lib.ts
@@ -16,8 +16,13 @@ const asyncExecFile = promisify(execFile)
 export const pullPackage = async (packageName: string): Promise<{packageFile: string, extractedFolder: string}> => {
   const {stdout: packStdout} = await asyncExecFile('npm', ['pack', packageName])
   const packageFile = packStdout.trim()
+  const precontents = new Set(shell.ls())
   await tar.extract({file: packageFile})
-  return {packageFile, extractedFolder: './package/'}
+  const postcontents = new Set(shell.ls())
+  const folderPath = 
+    [...postcontents].filter(x => !precontents.has(x))
+
+  return {packageFile, extractedFolder: './' + folderPath}
 }
 
 /**

--- a/tracer/src/lib.ts
+++ b/tracer/src/lib.ts
@@ -16,7 +16,6 @@ const asyncExecFile = promisify(execFile)
 export const pullPackage = async (packageName: string): Promise<{packageFile: string, extractedFolder: string}> => {
   const {stdout: packStdout} = await asyncExecFile('npm-bundle', [packageName])
   const packageFile = packStdout.trim()
-  console.error(`PACKAGEFILE: ${packageFile}`)
   const precontents = new Set(shell.ls())
   await tar.extract({file: packageFile})
   const postcontents = new Set(shell.ls())

--- a/tracer/src/untyped/npm-bundle.d.ts
+++ b/tracer/src/untyped/npm-bundle.d.ts
@@ -1,0 +1,5 @@
+declare module 'npm-bundle' {
+  function npmBundle(args: string[], options: {verbose: boolean}, cb: (error: Error, output: {file: string}) => void): void
+
+  export = npmBundle
+}

--- a/tracer/tsconfig.json
+++ b/tracer/tsconfig.json
@@ -42,7 +42,7 @@
     // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
     // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
     // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
-    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    "typeRoots": ["./src/untyped/"],          /* List of folders to include type definitions from. */
     // "types": [],                           /* Type declaration files to be included in compilation. */
     // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
     "esModuleInterop": true                   /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */

--- a/tracer/yarn.lock
+++ b/tracer/yarn.lock
@@ -1495,6 +1495,17 @@ glob-parent@^2.0.0:
   dependencies:
     is-glob "^2.0.0"
 
+glob@^6.0.1:
+  version "6.0.4"
+  resolved "https://registry.yarnpkg.com/glob/-/glob-6.0.4.tgz#0f08860f6a155127b2fadd4f9ce24b1aab6e4d22"
+  integrity sha1-DwiGD2oVUSey+t1PnOJLGqtuTSI=
+  dependencies:
+    inflight "^1.0.4"
+    inherits "2"
+    minimatch "2 || 3"
+    once "^1.3.0"
+    path-is-absolute "^1.0.0"
+
 glob@^7.0.0, glob@^7.0.3, glob@^7.0.5:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
@@ -1714,6 +1725,11 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
   integrity sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==
+
+insync@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/insync/-/insync-2.1.1.tgz#22e26c61121303c06f51d35a3ccf6d8fc1e914c4"
+  integrity sha1-IuJsYRITA8BvUdNaPM9tj8HpFMQ=
 
 interpret@^1.0.0:
   version "1.1.0"
@@ -2318,7 +2334,7 @@ mimic-fn@^1.0.0:
   resolved "https://registry.yarnpkg.com/mimic-fn/-/mimic-fn-1.2.0.tgz#820c86a39334640e99516928bd03fca88057d022"
   integrity sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
 
-minimatch@^3.0.0, minimatch@^3.0.4:
+"minimatch@2 || 3", minimatch@^3.0.0, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -2407,6 +2423,11 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
+ncp@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/ncp/-/ncp-2.0.0.tgz#195a21d6c46e361d2fb1281ba38b91e9df7bdbb3"
+  integrity sha1-GVoh1sRuNh0vsSgbo4uR6d9727M=
+
 needle@^2.2.1:
   version "2.2.4"
   resolved "https://registry.yarnpkg.com/needle/-/needle-2.2.4.tgz#51931bff82533b1928b7d1d69e01f1b00ffd2a4e"
@@ -2456,6 +2477,17 @@ normalize-path@^2.0.0, normalize-path@^2.0.1:
   integrity sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
   dependencies:
     remove-trailing-separator "^1.0.1"
+
+npm-bundle@^3.0.3:
+  version "3.0.3"
+  resolved "https://registry.yarnpkg.com/npm-bundle/-/npm-bundle-3.0.3.tgz#464e613f21f14e4918ed93e810b5a9cdeb35acc1"
+  integrity sha1-Rk5hPyHxTkkY7ZPoELWpzes1rME=
+  dependencies:
+    glob "^6.0.1"
+    insync "^2.1.1"
+    mkdirp "^0.5.1"
+    ncp "^2.0.0"
+    rimraf "^2.4.4"
 
 npm-bundled@^1.0.1:
   version "1.0.5"
@@ -3034,7 +3066,7 @@ ret@~0.1.10:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.1.15.tgz#b8a4825d5bdb1fc3f6f53c2bc33f81388681c7bc"
   integrity sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
 
-rimraf@^2.6.1:
+rimraf@^2.4.4, rimraf@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/rimraf/-/rimraf-2.6.2.tgz#2ed8150d24a16ea8651e6d6ef0f47c4158ce7a36"
   integrity sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==


### PR DESCRIPTION
Prior to this PR, the tracer would fail on cases where an npm package needed additional dependencies. The problem was that `npm pack <package>` did not add dependencies when it downloaded the zip of the package. At the same time though, we don't want to use `npm install`, as that wouldn't give us an opportunity to `strace` the command. 

We've changed the scirpt to utilize `npm-bundle`, which more or less does the same thing as `npm pack` except dependencies are included in the zip file. Additionally, we made the assignment of `extractedFolder` more robust. 